### PR TITLE
Fix clash with RuneLite slayer plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.8.18.2'
+def runeLiteVersion = '1.8.18.5'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
@@ -25,8 +25,8 @@ dependencies {
 	testImplementation "org.mockito:mockito-core:4.3.1"
 }
 
-group = 'com.example'
-version = '1.0-SNAPSHOT'
+group = 'com.slayerassistant'
+version = '1.0.1'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -3,4 +3,4 @@ author=LeeOKeefe
 support=https://github.com/LeeOkeefe/slayer-assistant-plugin
 description=Provides information on slayer tasks
 tags=slay,slayer,task
-plugins=com.slayerassistant.SlayerPlugin
+plugins=com.slayerassistant.SlayerAssistantPlugin

--- a/src/main/java/com/slayerassistant/SlayerAssistantPlugin.java
+++ b/src/main/java/com/slayerassistant/SlayerAssistantPlugin.java
@@ -13,11 +13,11 @@ import java.awt.image.BufferedImage;
 @PluginDescriptor(
 	name = "Slayer Assistant"
 )
-public class SlayerPlugin extends Plugin
+public class SlayerAssistantPlugin extends Plugin
 {
 	@Inject
 	private ClientToolbar clientToolbar;
-
+	
 	private SlayerPluginPanel slayerPanel;
 	private NavigationButton navButton;
 

--- a/src/test/java/com/slayerassistant/SlayerPluginTest.java
+++ b/src/test/java/com/slayerassistant/SlayerPluginTest.java
@@ -7,7 +7,7 @@ public class SlayerPluginTest
 {
 	public static void main(String[] args) throws Exception
 	{
-		ExternalPluginManager.loadBuiltin(SlayerPlugin.class);
+		ExternalPluginManager.loadBuiltin(SlayerAssistantPlugin.class);
 		RuneLite.main(args);
 	}
 }


### PR DESCRIPTION
The plugin class/file name for Slayer Assistant was 'SlayerPlugin', which is also the same name for the built in Slayer plugin from RuneLite.

The same naming was causing both plugins to be enabled/disabled, so the class/file for slayer assistant has been renamed to SlayerAssistantPlugin to avoid the naming clash.